### PR TITLE
enable ssl support for IDM redirection 

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,11 +1,21 @@
+#!/bin/bash
+
 if [ ! -f /etc/configured ]; then
    GW_HOST=${AGILE_HOST:-`cat /etc/hostname | xargs echo -n`.local}
-   grunt config -set=client.Connection.RedirectIDM --value=http://$GW_HOST:3000/oauth2/dialog/authorize/
+   if [ "$AGILE_SSL" == "1" ]
+   then
+       PROTO="https"
+       PORT=1444
+   else
+      PROTO="http"
+      PORT=3000
+   fi
+   grunt config -set=client.Connection.RedirectIDM --value=$PROTO://$GW_HOST:$PORT/oauth2/dialog/authorize/
    grunt
-   echo "var $GW_HOST"
+   echo "value for AGILE_SSL $AGILE_SSL"
+   echo "OS-JS configured to use IDM at: $PROTO://$GW_HOST:$PORT/oauth2/dialog/authorize/"
    echo "var $GW_HOST"
    touch /etc/configured
 fi
 
 ./bin/start-dev.sh
-


### PR DESCRIPTION
If AGILE_SSL=1 id defined env variable, then agile-osjs redirects to the https port instead of the http of IDM in agile-security.

In other words, the environment field on docker-compose should look like this:
    environment:
      - AGILE_HOST=$AGILE_HOST
      - AGILE_SSL=1

If there is no AGILE_SSL or if it is 0 http is used, as before

Also, I've checked and the build seems to have failed, but the image is in docker hub under the name that for the branch (ssl-redirect)  (https://hub.docker.com/r/agileiot/agile-osjs-armv7l/tags/). My local branch has a different name, maybe due to this mismatch in the metadata of the repo we had this issue?
I pulled the arm version (which in theory filed) but it is running