### PR TITLE
update Dockerfile and start script to install apps from /opt/osjs-app…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
-# 
+#
 # Contributors:
 #     Create-Net / FBK - initial API and implementation
 #-------------------------------------------------------------------------------
@@ -49,4 +49,5 @@ EXPOSE 8000:8000
 
 #CMD ./bin/start-dev.sh
 COPY ./start.sh  ./
+COPY ./install_apps.sh ./
 CMD ./start.sh

--- a/install_apps.sh
+++ b/install_apps.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+APPS='/opt/osjs-apps'
+
+for x in "$(ls  $APPS)"; do
+  echo "installing app $x"
+  cp -r $APPS/$x src/packages/default/$x
+  grunt manifest config packages:default/$x
+done
+grunt

--- a/start.sh
+++ b/start.sh
@@ -28,8 +28,11 @@ then
    echo "value for AGILE_SSL $AGILE_SSL"
    echo "OS-JS configured to use IDM at: $PROTO://$GW_HOST:$PORT/oauth2/dialog/authorize/"
    echo "var $GW_HOST"
+   ./install_apps.sh
    echo "$GW_HOST">/etc/configured
 fi
+
+
 
 
 ./bin/start-dev.sh


### PR DESCRIPTION
This PR includes the possibility to load OSJS apps when it starts (or when it must be reconfigured due to the a change in the AGILE HOST)  for the first time from a mapped folder. To test, clone the osjs sample (https://github.com/Agile-IoT/agile-osjs-sample) in 
$DATA/osjs-apps/,  run a service in port 4000 and then add this to the docker-compose file.

  agile-osjs:
    container_name: agile-osjs
    image: agileiot/agile-osjs-$AGILE_ARCH:dynamic-load
    #build: apps/agile-osjs
    depends_on:
      - agile-core
    environment:
      - AGILE_HOST=$AGILE_HOST
    ports:
      - 8000:8000/tcp
    restart: always
    volumes:
      - /etc/hostname:/etc/hostname
      - $DATA/osjs-apps/:/opt/osjs-apps/


Change-Type: minor